### PR TITLE
refactor(API): Diorama API URL

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -30,5 +30,8 @@ Although this plugin connects your WordPress website to Moving Digital it still 
 
 == Changelog ==
 
+= 1.0.1 =
+* API url changed
+
 = 1.0 =
 * Inital release

--- a/admin/class-moving-digital-realworks-admin.php
+++ b/admin/class-moving-digital-realworks-admin.php
@@ -315,7 +315,7 @@ class Moving_Digital_Realworks_Admin {
 			$apiKeyName    => $apiKey,
 		);
 
-		$url     = 'https://api.helpmee.nl/public/v1.4/' . $request;
+		$url     = 'https://app.diorama.nl/api/public/v1.4/' . $request;
 		$request = new \WP_Http;
 
 		return $request->request( $url, array( 'method' => 'GET', 'headers' => $headers ) );

--- a/moving-digital-realworks.php
+++ b/moving-digital-realworks.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Moving Digital - Realworks
  * Plugin URI:        https://www.webreact.nl
  * Description:       This plugin connects your WordPress website to Moving Digitals API. It's intended use is to pull data in from Realworks objects.
- * Version:           1.0.0
+ * Version:           1.0.1
  * Author:            Webreact (Nils Ringersma)
  * Author URI:        https://www.webreact.nl
  * License:           GPL-2.0+
@@ -40,7 +40,7 @@ require __DIR__ . '/vendor/autoload.php';
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'MOVING_DIGITAL_REALWORKS_VERSION', '1.0.0' );
+define( 'MOVING_DIGITAL_REALWORKS_VERSION', '1.0.1' );
 define( 'PLUGIN_DIR_PATH', plugin_dir_path( __FILE__ ) );
 
 /**


### PR DESCRIPTION
FD-178894 changed Diorama API URL

In deze pull request bevat 1 commit. Deze commit heeft de volgende informatie:

- De API URL is vervangen van helpmee naar diorama. (dit is getest in postman en hier komt dezelfde data uit)
- Type commit: refactor
- Het introduced geen breaking change
- De versie van de plugin is veranderd naar 1.0.1.

  